### PR TITLE
Add an option to decode numeric values with a trailing fractional zero

### DIFF
--- a/codecs/__init__.pxd
+++ b/codecs/__init__.pxd
@@ -120,6 +120,8 @@ cdef numeric_encode_text(CodecContext settings, WriteBuffer buf, obj)
 cdef numeric_decode_text(CodecContext settings, FRBuffer * buf)
 cdef numeric_encode_binary(CodecContext settings, WriteBuffer buf, obj)
 cdef numeric_decode_binary(CodecContext settings, FRBuffer * buf)
+cdef numeric_decode_binary_ex(CodecContext settings, FRBuffer * buf,
+                              bint trail_fract_zero)
 
 
 # Void


### PR DESCRIPTION
The new `numeric_decode_binary_ex` decoder variant is able to append a
trailing fractional zero digit to numeric values with zero scale.