### PR TITLE
Add unpack_uint32 function

### DIFF
--- a/hton.h
+++ b/hton.h
@@ -146,38 +146,50 @@ pack_int64(char *buf, int64_t x)
 }
 
 
-static inline int16_t
-unpack_int16(const char *buf)
+
+static inline uint16_t
+unpack_uint16(const char *buf)
 {
     uint16_t nx;
     memcpy((char *)&nx, buf, sizeof(uint16_t));
-    return (int16_t)apg_ntoh16(nx);
+    return apg_ntoh16(nx);
 }
 
 
-static inline int32_t
-unpack_int32(const char *buf)
+static inline int16_t
+unpack_int16(const char *buf)
 {
-    uint32_t nx;
-    memcpy((char *)&nx, buf, sizeof(uint32_t));
-    return (int32_t)apg_ntoh32(nx);
+    return (int16_t)unpack_uint16(buf);
 }
+
 
 static inline uint32_t
 unpack_uint32(const char *buf)
 {
     uint32_t nx;
     memcpy((char *)&nx, buf, sizeof(uint32_t));
-    return (uint32_t)apg_ntoh32(nx);
+    return apg_ntoh32(nx);
 }
 
+
+static inline int32_t
+unpack_int32(const char *buf)
+{
+    return (int32_t)unpack_uint32(nx);
+}
+
+static inline uint64_t
+unpack_uint64(const char *buf)
+{
+    uint64_t nx;
+    memcpy((char *)&nx, buf, sizeof(uint64_t));
+    return apg_ntoh64(nx);
+}
 
 static inline int64_t
 unpack_int64(const char *buf)
 {
-    uint64_t nx;
-    memcpy((char *)&nx, buf, sizeof(uint64_t));
-    return (int64_t)apg_ntoh64(nx);
+    return (int64_t)unpack_uint64(buf);
 }
 
 

--- a/hton.h
+++ b/hton.h
@@ -175,7 +175,7 @@ unpack_uint32(const char *buf)
 static inline int32_t
 unpack_int32(const char *buf)
 {
-    return (int32_t)unpack_uint32(nx);
+    return (int32_t)unpack_uint32(buf);
 }
 
 static inline uint64_t

--- a/hton.h
+++ b/hton.h
@@ -163,6 +163,14 @@ unpack_int32(const char *buf)
     return (int32_t)apg_ntoh32(nx);
 }
 
+static inline uint32_t
+unpack_uint32(const char *buf)
+{
+    uint32_t nx;
+    memcpy((char *)&nx, buf, sizeof(uint32_t));
+    return (uint32_t)apg_ntoh32(nx);
+}
+
 
 static inline int64_t
 unpack_int64(const char *buf)

--- a/hton.pxd
+++ b/hton.pxd
@@ -15,8 +15,10 @@ cdef extern from "./hton.h":
     cdef void pack_float(char *buf, float f);
     cdef void pack_double(char *buf, double f);
     cdef int16_t unpack_int16(const char *buf);
+    cdef uint16_t unpack_uint16(const char *buf);
     cdef int32_t unpack_int32(const char *buf);
     cdef uint32_t unpack_uint32(const char *buf);
     cdef int64_t unpack_int64(const char *buf);
+    cdef uint64_t unpack_uint64(const char *buf);
     cdef float unpack_float(const char *buf);
     cdef double unpack_double(const char *buf);

--- a/hton.pxd
+++ b/hton.pxd
@@ -16,6 +16,7 @@ cdef extern from "./hton.h":
     cdef void pack_double(char *buf, double f);
     cdef int16_t unpack_int16(const char *buf);
     cdef int32_t unpack_int32(const char *buf);
+    cdef uint32_t unpack_uint32(const char *buf);
     cdef int64_t unpack_int64(const char *buf);
     cdef float unpack_float(const char *buf);
     cdef double unpack_double(const char *buf);


### PR DESCRIPTION
This function is needed to unpack strings in type descriptors. I'm not sure it's a good idea to add it here, though. But all other functions we use are from this module.