### PR TITLE
buffer: Handle bytearray as input

### DIFF
--- a/buffer.pyx
+++ b/buffer.pyx
@@ -263,6 +263,9 @@ cdef class ReadBuffer:
 
         if not cpythonx.PyBytes_CheckExact(data):
             if cpython.PyByteArray_CheckExact(data):
+                # ProactorEventLoop in Python 3.10+ seems to be sending
+                # bytearray objects instead of bytes.  Handle this here
+                # to avoid duplicating this check in every data_received().
                 data = bytes(data)
             else:
                 raise BufferError(

--- a/buffer.pyx
+++ b/buffer.pyx
@@ -261,11 +261,12 @@ cdef class ReadBuffer:
             ssize_t dlen
             bytes data_bytes
 
-        if cpythonx.PyByteArray_CheckExact(data):
-            data = bytes(data)
-        elif not cpython.PyBytes_CheckExact(data):
-            raise BufferError(
-                'feed_data: a bytes or bytearray object expected')
+        if not cpythonx.PyBytes_CheckExact(data):
+            if cpython.PyByteArray_CheckExact(data):
+                data = bytes(data)
+            else:
+                raise BufferError(
+                    'feed_data: a bytes or bytearray object expected')
 
         # Uncomment the below code to test code paths that
         # read single int/str/bytes sequences are split over

--- a/buffer.pyx
+++ b/buffer.pyx
@@ -261,8 +261,11 @@ cdef class ReadBuffer:
             ssize_t dlen
             bytes data_bytes
 
-        if not cpython.PyBytes_CheckExact(data):
-            raise BufferError('feed_data: bytes object expected')
+        if cpythonx.PyByteArray_CheckExact(data):
+            data = bytes(data)
+        elif not cpython.PyBytes_CheckExact(data):
+            raise BufferError(
+                'feed_data: a bytes or bytearray object expected')
 
         # Uncomment the below code to test code paths that
         # read single int/str/bytes sequences are split over

--- a/cpythonx.pxd
+++ b/cpythonx.pxd
@@ -10,6 +10,7 @@ from cpython cimport Py_buffer
 cdef extern from "Python.h":
     int PyUnicode_1BYTE_KIND
 
+    int PyByteArray_CheckExact(object)
     int PyByteArray_Resize(object, ssize_t) except -1
     object PyByteArray_FromStringAndSize(const char *, ssize_t)
     char* PyByteArray_AsString(object)


### PR DESCRIPTION
In Python 3.10 the Windows proactor event loop can send a bytearray
object instead of bytes to protocol's `data_received`