### PR TITLE
Export json_encode/decode functions

### DIFF
--- a/codecs/__init__.pxd
+++ b/codecs/__init__.pxd
@@ -103,6 +103,8 @@ cdef float8_decode(CodecContext settings, FRBuffer * buf)
 # JSON
 cdef jsonb_encode(CodecContext settings, WriteBuffer buf, obj)
 cdef jsonb_decode(CodecContext settings, FRBuffer * buf)
+cdef json_encode(CodecContext settings, WriteBuffer buf, obj)
+cdef json_decode(CodecContext settings, FRBuffer *buf)
 
 
 # JSON path


### PR DESCRIPTION
Otherwise we get compilation warnings:

```
asyncpg/pgproto/pgproto.c:23994:18: warning: ‘__pyx_f_7asyncpg_7pgproto_7pgproto_json_decode’ defined but not used [-Wunused-function]
23994 | static PyObject *__pyx_f_7asyncpg_7pgproto_7pgproto_json_decode(struct __pyx_obj_7asyncpg_7pgproto_7pgproto_CodecContext *__pyx_v_settings, struct __pyx_t_7asyncpg_7pgproto_7pgproto_FRBuffer *__pyx_v_buf) {
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asyncpg/pgproto/pgproto.c:23886:18: warning: ‘__pyx_f_7asyncpg_7pgproto_7pgproto_json_encode’ defined but not used [-Wunused-function]
23886 | static PyObject *__pyx_f_7asyncpg_7pgproto_7pgproto_json_encode(struct __pyx_obj_7asyncpg_7pgproto_7pgproto_CodecContext *__pyx_v_settings, struct __pyx_obj_7asyncpg_7pgproto_7pgproto_WriteBuffer *__pyx_v_buf, PyObject *__pyx_v_obj) {
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```