### PR TITLE
`typing.Text` is deprecated

### DIFF
--- a/types.py
+++ b/types.py
@@ -253,14 +253,14 @@ class Point(typing.Tuple[float, float]):
         x: (
             typing.SupportsFloat |
             typing.SupportsIndex |
-            typing.Text |
+            str |
             builtins.bytes |
             builtins.bytearray
         ),
         y: (
             typing.SupportsFloat |
             typing.SupportsIndex |
-            typing.Text |
+            str |
             builtins.bytes |
             builtins.bytearray
         )


### PR DESCRIPTION
Use `str` instead. 
Source: 
- https://github.com/python/cpython/blob/35b5eaa176a5bae8a0cacb9c9f40ec948ecc4325/Lib/typing.py#L3419-L3420
- https://github.com/python/cpython/issues/92332