### PR TITLE
Make redirect_messages return count

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,1 @@
-Low-level IO utilities for PosgtreSQL drivers.
+Low-level IO utilities for PostgreSQL drivers.

--- a/buffer.pxd
+++ b/buffer.pxd
@@ -127,7 +127,7 @@ cdef class ReadBuffer:
     cdef inline const char* try_consume_message(self, ssize_t* len)
     cdef bytes consume_message(self)
     cdef discard_message(self)
-    cdef redirect_messages(self, WriteBuffer buf, char mtype, int stop_at=?)
+    cdef int32_t redirect_messages(self, WriteBuffer buf, char mtype, int stop_at=?)
     cdef bytearray consume_messages(self, char mtype)
     cdef finish_message(self)
     cdef inline _finish_message(self)


### PR DESCRIPTION
Make `ReadBuffer.redirect_messages` return the number of messages redirected. This is needed for counting `RowDescription` messages to figure out how many rows were modified by DML statements.