### PR TITLE
Add `str` type to `__init__` method for `BitString`

### DIFF
--- a/types.py
+++ b/types.py
@@ -35,7 +35,7 @@ class BitString:
     _bitlength: int
 
     def __init__(self,
-                 bitstring: builtins.bytes | None = None) -> None:
+                 bitstring: builtins.bytes | str | None = None) -> None:
         if not bitstring:
             self._bytes = bytes()
             self._bitlength = 0


### PR DESCRIPTION
This fixes typing errors with:

```python
asyncpg.BitString('101')
```

Relevant tests: https://github.com/MagicStack/asyncpg/blob/v0.31.0/tests/test_codecs.py#L409